### PR TITLE
update is-empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ava": "*"
   },
   "dependencies": {
-    "is-empty": "0.0.1",
+    "is-empty": "^1.0.0",
     "is-whitespace": "^0.3.0"
   }
 }


### PR DESCRIPTION
is-empty has some bug fixes. A looser version requirement will allow also is-empty to change

potentially the version requirement could be even looser